### PR TITLE
Fix dependency on EditorFramework module for UE4.27 and older

### DIFF
--- a/Source/RiderSourceCodeAccess/RiderSourceCodeAccess.Build.cs
+++ b/Source/RiderSourceCodeAccess/RiderSourceCodeAccess.Build.cs
@@ -22,7 +22,9 @@ namespace UnrealBuildTool.Rules
 
 			if (Target.Type == TargetType.Editor)
 			{
+				#if UE_5_0_OR_LATER
 				PrivateDependencyModuleNames.Add("EditorFramework");
+				#endif
 				PrivateDependencyModuleNames.Add("UnrealEd");
 				PrivateDependencyModuleNames.Add("GameProjectGeneration");
 			}


### PR DESCRIPTION
Dependency on EditorFramework module is required for UE5, but having project on UE4 nothing works due to this module doesn't exist in UE4 distributions, so we need to check whether we're using UE5 or not