### PR TITLE
Fix linker issue: undefined symbol: FOptionalSize::Unspecified

### DIFF
--- a/Source/RiderSourceCodeAccess/RiderSourceCodeAccess.Build.cs
+++ b/Source/RiderSourceCodeAccess/RiderSourceCodeAccess.Build.cs
@@ -16,7 +16,8 @@ namespace UnrealBuildTool.Rules
 					"Projects",
 					"Json",
 					"Projects",
-					"Slate"
+					"Slate",
+					"SlateCore"
 				}
 			);
 


### PR DESCRIPTION
I get the following error with 4.27 on Linux:

```
Building MamadouArchivesEditor...
Performing 3 actions (16 in parallel)
[1/3] Compile Module.RiderSourceCodeAccess.cpp
[2/3] Link (lld) libUE4Editor-RiderSourceCodeAccess.so
0>ld.lld: Error  : undefined symbol: FOptionalSize::Unspecified
>>> referenced by SlateStructs.h:17 (Runtime/SlateCore/Public/Types/SlateStructs.h:17)
>>>               /home/mamadou/dev/MamadouArchives/Engine/Plugins/Developer/RiderSourceCodeAccess/Intermediate/Build/Linux/B4D820EA/UE4Editor/Development/RiderSourceCodeAccess/Module.RiderSourceCodeAccess.cpp.o:(FNotificationInfo::FNotificationInfo(FText const&))
0>clang++: Error  : linker command failed with exit code 1 (use -v to see invocation)
Build failed at 1:51:50 PM 
```

[According to the documentation](https://docs.unrealengine.com/4.27/en-US/API/Runtime/SlateCore/Types/FOptionalSize/), FOptionalSize struct is part of the SlateCore module so it should be added to PrivateDependencyModuleNames in order for libUE4Editor-RiderSourceCodeAccess.so to link successfully.