### PR TITLE
add the missing bracket that causes build failure

### DIFF
--- a/Source/RiderSourceCodeAccess/Private/RiderSourceCodeAccessor.cpp
+++ b/Source/RiderSourceCodeAccess/Private/RiderSourceCodeAccessor.cpp
@@ -114,6 +114,7 @@ bool CheckExecutable(const FString& App)
 }
 
 bool OpenRider(const FString& ExecutablePath, const FString& Params, const FString& ErrorMessage)
+{
 	const FCommandLineInfo PlatformAppAndArgs = GetPlatformAppAndArgs(ExecutablePath, Params);
 	if(!CheckExecutable(PlatformAppAndArgs.App))
 	{


### PR DESCRIPTION
I am getting the following build error against the master. It turned out a open bracket is missing:

```
[1278/1420] Compile Module.RiderSourceCodeAccess.cpp
In file included from ../Plugins/Developer/RiderSourceCodeAccess/Intermediate/Build/Linux/x64/UnrealEditor/Development/RiderSourceCodeAccess/Module.RiderSourceCodeAccess.cpp:5:
/home/mamadou/dev/MamadouArchives/Engine/Plugins/Developer/RiderSourceCodeAccess/Source/RiderSourceCodeAccess/Private/RiderSourceCodeAccessor.cpp:117:2: error: non-member function cannot have 'const' qualifier
        const FCommandLineInfo PlatformAppAndArgs = GetPlatformAppAndArgs(ExecutablePath, Params);
        ^~~~~~
/home/mamadou/dev/MamadouArchives/Engine/Plugins/Developer/RiderSourceCodeAccess/Source/RiderSourceCodeAccess/Private/RiderSourceCodeAccessor.cpp:117:7: error: expected ';' after top level declarator
        const FCommandLineInfo PlatformAppAndArgs = GetPlatformAppAndArgs(ExecutablePath, Params);
             ^
             ;
/home/mamadou/dev/MamadouArchives/Engine/Plugins/Developer/RiderSourceCodeAccess/Source/RiderSourceCodeAccess/Private/RiderSourceCodeAccessor.cpp:117:68: error: use of undeclared identifier 'ExecutablePath'
        const FCommandLineInfo PlatformAppAndArgs = GetPlatformAppAndArgs(ExecutablePath, Params);
                                                                          ^
/home/mamadou/dev/MamadouArchives/Engine/Plugins/Developer/RiderSourceCodeAccess/Source/RiderSourceCodeAccess/Private/RiderSourceCodeAccessor.cpp:117:84: error: use of undeclared identifier 'Params'
        const FCommandLineInfo PlatformAppAndArgs = GetPlatformAppAndArgs(ExecutablePath, Params);
                                                                                          ^
/home/mamadou/dev/MamadouArchives/Engine/Plugins/Developer/RiderSourceCodeAccess/Source/RiderSourceCodeAccess/Private/RiderSourceCodeAccessor.cpp:118:2: error: expected unqualified-id
        if(!CheckExecutable(PlatformAppAndArgs.App))
        ^
/home/mamadou/dev/MamadouArchives/Engine/Plugins/Developer/RiderSourceCodeAccess/Source/RiderSourceCodeAccess/Private/RiderSourceCodeAccessor.cpp:125:2: error: expected unqualified-id
        if (!bResult)
        ^
/home/mamadou/dev/MamadouArchives/Engine/Plugins/Developer/RiderSourceCodeAccess/Source/RiderSourceCodeAccess/Private/RiderSourceCodeAccessor.cpp:131:2: error: expected unqualified-id
        return bResult;
        ^
/home/mamadou/dev/MamadouArchives/Engine/Plugins/Developer/RiderSourceCodeAccess/Source/RiderSourceCodeAccess/Private/RiderSourceCodeAccessor.cpp:134:1: error: extraneous closing brace ('}')
}
^
```